### PR TITLE
Clean dir fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.3.1
+-----
+
+* Fix to prevent /etc/backup.d cleaning from causing recreate of files within
+
 0.3.0
 -----
 

--- a/backupninja/init.sls
+++ b/backupninja/init.sls
@@ -78,6 +78,9 @@ backupninja:
     - user: root
     - group: root
     - mode: 600
+    - makedirs: True
+    - require_in:
+      - file: /etc/backup.d
 
 {% if backupninja.duplicity.hourly.enabled %}
 /etc/backup.d/80.dup:
@@ -88,6 +91,9 @@ backupninja:
     - user: root
     - group: root
     - mode: 600
+    - makedirs: True
+    - require_in:
+      - file: /etc/backup.d
 {% endif %}
 
 {% if backupninja.duplicity.enabled %}
@@ -99,6 +105,9 @@ backupninja:
     - user: root
     - group: root
     - mode: 600
+    - makedirs: True
+    - require_in:
+      - file: /etc/backup.d
 {% endif %}
 
 


### PR DESCRIPTION
correct the order of operations for cleaning /etc/backup.d so files are not constantly recreated
