### PR TITLE
Allow default states to be turned off

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,11 @@ The following pillars *must* be provided::
     backupninja.duplicity.awsaccesskeyid        # aws credentials
     backupninja.duplicity.awssecretaccesskeyid
 
+If you don't like the default backup behaviour, and want to customise it fully,
+you can set the following pillar to False, to disable the 10.sys and 90.dup states::
+
+    backupninja.disable_default_backup_states: True
+
 To enable the hourly backup set, you must set::
 
     backupninja.duplicity.hourly.enabled: True

--- a/backupninja/init.sls
+++ b/backupninja/init.sls
@@ -90,7 +90,13 @@ backupninja:
     - require:
       - pkg: backupninja
 
+# Because of the require_in we can't turn off this state via
+# exclude, so adding a pillar to turn it off
 /etc/backup.d/10.sys:
+{% if backupninja.disable_default_backup_states %}
+  file:
+    - absent
+{% else %}
   file:
     - managed
     - source: salt://backupninja/templates/backup.d/10.sys
@@ -101,6 +107,7 @@ backupninja:
     - makedirs: True
     - require_in:
       - file: /etc/backup.d
+{% endif %}
 
 {% if backupninja.duplicity.hourly.enabled %}
 /etc/backup.d/80.dup:
@@ -118,6 +125,10 @@ backupninja:
 
 {% if backupninja.duplicity.enabled %}
 /etc/backup.d/90.dup:
+{% if backupninja.disable_default_backup_states %}
+  file:
+    - absent
+{% else %}
   file:
     - managed
     - source: salt://backupninja/templates/backup.d/90.dup
@@ -128,6 +139,7 @@ backupninja:
     - makedirs: True
     - require_in:
       - file: /etc/backup.d
+{% endif %}
 {% endif %}
 
 
@@ -199,8 +211,13 @@ backupninja:
       - pkg: backupninja
 
 {{backupninja.backup_base_dir}}/sys:
+{% if backupninja.disable_default_backup_states %}
+  file:
+    - absent
+{% else %}
   file:
     - directory
     - user: root
     - group: root
     - mode: 0750
+{% endif %}

--- a/backupninja/map.jinja
+++ b/backupninja/map.jinja
@@ -1,6 +1,7 @@
 {% set backupninja = salt['grains.filter_by']({
     'Debian': {
         'backup_base_dir': '/var/backups',
+        'disable_default_backup_states': False,
         'duplicity': {
           'enabled': True,
           'keep': '60',


### PR DESCRIPTION
When trying to use duplicity a couple of states are turned on
by default, so provide a way to turn that off.

Trying to exclude the states using an sls like: 
```
exclude:
  - id: {{backupninja.backup_base_dir}}/sys
  - id: /etc/backup.d/10.sys
```
causes problems because of the `require_in` in `10.sys`, and trying to workaround that via deleting the file later on causes things like `Comment: Recursive requisite found` or similar. 